### PR TITLE
Add ruby implementations to resolvedomains

### DIFF
--- a/resolvedomains/README.md
+++ b/resolvedomains/README.md
@@ -1,5 +1,19 @@
 ## Resolve domains 
 Asynchronous dns resolver written in python (30 threads)
 
-## Example:
-``` cat domainlist.txt | python3 resolvedomains.py > ip_addresses```
+## Python Example:
+```python
+cat domainlist.txt | python3 resolvedomains.py > ip_addresses
+```
+
+## Ruby Example:
+```ruby
+cat domainlist.txt | ruby resolvedomains.rb > ip_addresses
+```
+
+or
+
+```ruby
+cat domainlist.txt | resolvedomains.rb > ip_addresses
+```
+

--- a/resolvedomains/README.md
+++ b/resolvedomains/README.md
@@ -9,11 +9,11 @@ cat domainlist.txt | python3 resolvedomains.py > ip_addresses
 ## Ruby Example:
 ```ruby
 cat domainlist.txt | ruby resolvedomains.rb > ip_addresses
+# useful for bbrf
+cat domainlist.txt | ruby resolvedomains.rb -v > ips_hosts 
 ```
 
-or
-
-```ruby
-cat domainlist.txt | resolvedomains.rb > ip_addresses
+```bash
+$ awk '{print $1}' ip_addresses_verbose > resolved_hosts
+$ awk '{print $2}' ip_addresses_verbose > ip_addresses
 ```
-

--- a/resolvedomains/resolvedomains.rb
+++ b/resolvedomains/resolvedomains.rb
@@ -1,0 +1,55 @@
+require 'resolv'
+require 'set'
+
+class Resolver
+  attr_reader :ip_addresses
+
+  def initialize(string)
+    @ip_addresses = []
+    if Resolver.is_ip_addr?(string)
+      @ip_addresses << string
+    else
+      resolved = Resolver.resolve(string)
+      @ip_addresses += resolved unless resolved.nil?
+    end
+  end
+
+  def is_domain_here?(domain)
+    ip_addresses = Resolver.resolve(domain)
+    return false if ip_addresses.nil?
+    ip_addresses.any? { |ip_addr| @ip_addresses.include?(ip_addr) }
+  end
+
+  def self.is_ip_addr?(string)
+    !!(string =~ /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/)
+  end
+
+  def self.resolve(domain)
+    begin
+      Resolv.getaddresses(domain).map(&:to_s)
+    rescue Resolv::ResolvError, Resolv::NoAnswer, Resolv::NoNameservers => e
+      nil
+    end
+  end
+end
+
+def solve_ip_addresses(s)
+  r = Resolver.new(s)
+  r.ip_addresses
+end
+
+def main
+  lines = $stdin.read.split("\n").uniq
+  resolved = Set.new
+  lines.each_slice(30) do |batch|
+    batch_resolved = batch.map { |line| solve_ip_addresses(line) }.flatten.uniq
+    batch_resolved.each do |ip_addr|
+      unless resolved.include?(ip_addr)
+        resolved << ip_addr
+        puts ip_addr
+      end
+    end
+  end
+end
+
+main


### PR DESCRIPTION
I redid your script in ruby because that is what my Automation Framework is written in, and so I just thought i'd see if you were interested in adding it. If you are wanting to stick to python or whatever, that's fine no worries at all. The Ruby version also adds an optional -h and -v or --verbose, where instead of just the ip it outputs the corresponding hostname as well